### PR TITLE
[Bei-806] update fullstack interview service to python 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,21 +5,17 @@ A basic note-taking API which Supports CRUD operations via a RESTful API for man
 
 Run all instructions from within the note-taking repository root folder.
 
-Runs on Python 2.7, installation guide [found here](http://docs.python-guide.org/en/latest/starting/install/osx/#install-osx).
+Runs on Python 3.4+, installation guide [found here](https://docs.python-guide.org/starting/install3/osx/#install3-osx).
 
-If `pip` is not installed, first ensure you have [easy_install](https://setuptools.readthedocs.io/en/latest/easy_install.html#installing-easy-install) installed and then install with:
+You should already have `pip` installed if you're runnign Python 3.4+, so the only dependencies required are Flask and Flask CORS:
 
-```sudo easy_install pip```
-
-Once you have `pip`, the only dependencies required are Flask and Flask CORS:
-
-```sudo pip install flask flask_cors```
+```sudo python3 -m pip install flask flask_cors```
 
 **Running**
 
 Once you have all dependencies installed, the server can be run with:
 
-```FLASK_APP=server.py flask run```
+```FLASK_APP=server.py FLASK_ENV=development flask run```
 
 This will bind the web server to port 5000 locally.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Run all instructions from within the note-taking repository root folder.
 
 Runs on Python 3.4+, installation guide [found here](https://docs.python-guide.org/starting/install3/osx/#install3-osx).
 
-You should already have `pip` installed if you're runnign Python 3.4+, so the only dependencies required are Flask and Flask CORS:
+You should already have `pip` installed if you're running Python 3.4+, so the only dependencies required are Flask and Flask CORS:
 
 ```sudo python3 -m pip install flask flask_cors```
 

--- a/server.py
+++ b/server.py
@@ -116,7 +116,7 @@ def add_note(note):
 
 @app.route('/notes')
 def get_all_notes():
-    return jsonify(get_notes().values())
+    return jsonify(list(get_notes().values()))
 
 
 @app.route('/notes/<int:id>')


### PR DESCRIPTION
[Bei-806] 
- update code to run on python 3
- update README to use python 3
- update README to call flask with a `development` environment flag.